### PR TITLE
Change

### DIFF
--- a/lib/kuby/kube-db/plugin.rb
+++ b/lib/kuby/kube-db/plugin.rb
@@ -54,37 +54,37 @@ module Kuby
       private
 
       def install_operator
-        helm_cli.install_chart(OPERATOR_CHART_NAME, {
+        helm_cli.install_chart(OPERATOR_CHART_NAME,
           release: OPERATOR_RELEASE_NAME,
           version: Kuby::KubeDB::KUBEDB_VERSION,
           namespace: NAMESPACE,
           params: OPERATOR_PARAMS
-        })
+        )
       end
 
       def upgrade_operator
-        helm_cli.upgrade_chart(OPERATOR_CHART_NAME, {
+        helm_cli.upgrade_chart(OPERATOR_CHART_NAME,
           release: OPERATOR_RELEASE_NAME,
           version: Kuby::KubeDB::KUBEDB_VERSION,
           namespace: NAMESPACE,
           params: OPERATOR_PARAMS
-        })
+        )
       end
 
       def install_catalog
-        helm_cli.install_chart(CATALOG_CHART_NAME, {
+        helm_cli.install_chart(CATALOG_CHART_NAME,
           release: CATALOG_RELEASE_NAME,
           version: Kuby::KubeDB::KUBEDB_VERSION,
           namespace: NAMESPACE
-        })
+        )
       end
 
       def upgrade_catalog
-        helm_cli.upgrade_chart(CATALOG_CHART_NAME, {
+        helm_cli.upgrade_chart(CATALOG_CHART_NAME,
           release: CATALOG_RELEASE_NAME,
           version: Kuby::KubeDB::KUBEDB_VERSION,
           namespace: NAMESPACE
-        })
+        )
       end
 
       def wait_for_operator


### PR DESCRIPTION
I was getting this error when following the getting started guide on a completely new Rails 6.1.3 project (latest Ruby: 3.0.1):

    bundle exec kuby -e production setup

Gave me: 

    bundle exec kuby -e production setup
    Setting up kubedb
    Fetching Helm chart
    "appscode" has been added to your repositories
    Hang tight while we grab the latest from your chart repositories...
    ...Successfully got an update from the "appscode" chart repository
    ...Successfully got an update from the "stable" chart repository
    Update Complete. ⎈ Happy Helming!⎈
    Deploying kubedb operator
    Error: release: not found
    error: wrong number of arguments (given 2, expected 1; required keywords: release, version)

By changing these methods it was fixed and the command ran successfully.